### PR TITLE
Deleting field no longer causes crash. 

### DIFF
--- a/src/components/editor/metaform-editor-right-drawer-feature.tsx
+++ b/src/components/editor/metaform-editor-right-drawer-feature.tsx
@@ -336,6 +336,9 @@ const MetaformEditorRightDrawerFeatureComponent: FC<Props> = ({
    */
   const checkContextSettings = () => {
     if (fieldIndex !== undefined && sectionIndex !== undefined) {
+      if (!pendingForm.sections![sectionIndex].fields![fieldIndex]) {
+        return;
+      }
       setContextOption([]);
       pendingForm.sections![sectionIndex].fields![fieldIndex].contexts!.forEach(context => {
         setContextOption(contextOptionList => [...contextOptionList, context as FormContext]);

--- a/src/components/generic/drag-handle/section-drag-handle.tsx
+++ b/src/components/generic/drag-handle/section-drag-handle.tsx
@@ -33,13 +33,6 @@ const SectionDragHandle: React.FC<Props> = ({
         <Edit/>
       </IconButton>
       <IconButton
-        disabled={ !onEditClick }
-        sx={{ color: "#fff" }}
-        onClick={ onEditClick }
-      >
-        <Edit/>
-      </IconButton>
-      <IconButton
         disabled={ !onDeleteClick }
         sx={{ color: "#fff" }}
         onClick={ onDeleteClick }


### PR DESCRIPTION
Also removed duplicate edit icons in section drag handle.
Resolves #180 and #181 