### PR TITLE
Switch for allowing past days. Default to true

### DIFF
--- a/src/components/editor/feature-components/MetaformDateTimeComponent.tsx
+++ b/src/components/editor/feature-components/MetaformDateTimeComponent.tsx
@@ -28,7 +28,8 @@ const MetaformDateTimeComponent: FC<Props> = ({
     if (metaformSectionIndex !== undefined && metaformFieldIndex !== undefined) {
       setMetaformField(pendingForm.sections?.[metaformSectionIndex].fields?.[metaformFieldIndex]);
     }
-  }, [metaformFieldIndex, metaformSectionIndex, metaformVersion]);
+  }, [ metaformFieldIndex, metaformSectionIndex, metaformVersion ]);
+
   /**
    * Updates allows work days only for date, date-time field
    *
@@ -42,6 +43,24 @@ const MetaformDateTimeComponent: FC<Props> = ({
     const updatedField = produce(metaformField, draftField => {
       draftField.workdaysOnly = checked;
     });
+    setMetaformField(updatedField);
+    updateFormFieldDebounced(updatedField);
+  };
+  
+  /**
+   * Updates allow past days only for date, date-time field
+   * 
+   * @param checked checked value of the checkbox value true or false
+   */
+  const updateAllowPastDays = (checked: boolean) => {
+    if (!metaformField) {
+      return;
+    }
+    
+    const updatedField = produce(metaformField, draftDield => {
+      draftDield.allowPastDays = checked;
+    });
+    
     setMetaformField(updatedField);
     updateFormFieldDebounced(updatedField);
   };
@@ -64,11 +83,26 @@ const MetaformDateTimeComponent: FC<Props> = ({
               />
             }
           />
+          <FormControlLabel
+            label={ strings.draftEditorScreen.editor.features.field.allowPast }
+            control={
+              <Switch
+                checked={ field.allowPastDays }
+                onChange={ ({ target }) => updateAllowPastDays(target.checked) }
+              />
+            }
+          />
         </Stack>
       );
     }
   };
 
+  useEffect(() => {
+    if (metaformField?.allowPastDays === undefined) {
+      updateAllowPastDays(true);
+    }
+  }, [ metaformField ]);
+  
   /**
    * Component render
    */

--- a/src/components/generic/form.tsx
+++ b/src/components/generic/form.tsx
@@ -77,6 +77,20 @@ const Form: React.FC<Props> = ({
   const handleDateTimeChange = (date: Date | null, fieldName: string) => {
     setFieldValue(fieldName, date ? moment(date).toISOString() : null);
   };
+  
+  /**
+   * Checks whether past days should be disabled for given date/date-time field
+   * 
+   * @param field field
+   * @returns Whether past days should be disabled or not
+   */
+  const checkDisablePastDays = (field: MetaformField) => {
+    if (field.allowPastDays === undefined) {
+      return false;
+    }
+    
+    return !field.allowPastDays;
+  };
 
   /**
    * Renders date picker with disabled past dates and disabled current date 
@@ -90,8 +104,7 @@ const Form: React.FC<Props> = ({
     return (
       <LocalizationProvider dateAdapter={ AdapterDateFns } locale={ fiLocale }>
         <DatePicker
-          disablePast={ true }
-          minDate={ moment().add(1, "days").toDate() }
+          disablePast={ checkDisablePastDays(field) }
           label={ strings.formComponent.datePicker }
           aria-label={ fieldName }
           shouldDisableDate={ MetaformUtils.shouldDisableHolidays(field.workdaysOnly || false) }
@@ -130,8 +143,7 @@ const Form: React.FC<Props> = ({
     return (
       <LocalizationProvider dateAdapter={ AdapterDateFns } locale={ fiLocale }>
         <MobileDateTimePicker
-          disablePast={ true }
-          minDate={ moment().add(1, "days").toDate() }
+          disablePast={ checkDisablePastDays(field) }
           aria-label={ fieldName }
           shouldDisableDate={ MetaformUtils.shouldDisableHolidays(field.workdaysOnly || false) }
           value={ value ? new Date(value as string) : null }

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -293,6 +293,7 @@
           "addCustomHtml": "Add HTML code in field",
           "contextVisibilityInfo": "Field management settings",
           "workDaysOnly": "Work days only",
+          "allowPast": "Past days",
           "slider": {
             "minValueLabel": "Field minimum value",
             "maxValueLabel": "Field maximum value"

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -294,6 +294,7 @@
           "addCustomHtml": "Lisää tähän HTML-sisältöä",
           "contextVisibilityInfo": "Kentän hallinnointi asetukset",
           "workDaysOnly": "Vain työpäivät",
+          "allowPast": "Menneet päivät",
           "slider": {
             "minValueLabel": "Kentän pienin arvo",
             "maxValueLabel": "Kentän suurin arvo"

--- a/src/localization/strings.ts
+++ b/src/localization/strings.ts
@@ -330,6 +330,7 @@ export interface Localized extends LocalizedStringsMethods {
           addCustomHtml: string;
           contextVisibilityInfo: string;
           workDaysOnly: string;
+          allowPast: string;
           slider: {
             minValueLabel: string;
             maxValueLabel: string;

--- a/src/utils/metaform-utils.ts
+++ b/src/utils/metaform-utils.ts
@@ -231,6 +231,17 @@ namespace MetaformUtils {
           type: fieldType,
           contexts: [ FormContext.FORM, FormContext.MANAGEMENT ]
         };
+      case MetaformFieldType.Date:
+      case MetaformFieldType.DateTime:
+        return {
+          name: name ?? fieldType + uuid4(),
+          title: title ?? LocalizationUtils.getLocalizedFieldType(fieldType),
+          required: required ?? false,
+          text: name ?? fieldType + uuid4(),
+          type: fieldType,
+          contexts: [ FormContext.FORM, FormContext.MANAGEMENT ],
+          allowPastDays: true
+        };
       default:
         return {
           name: name ?? fieldType + uuid4(),


### PR DESCRIPTION
Resolves #292 
Added new property for MetaformField in specifications, allowPastDays. It'll be undefined in current production forms and therefore the logic for defaulting it to true (as requested).